### PR TITLE
Bug domain parse

### DIFF
--- a/powerdnsadmin/lib/utils.py
+++ b/powerdnsadmin/lib/utils.py
@@ -4,7 +4,6 @@ import json
 import requests
 import hashlib
 import ipaddress
-import traceback
 
 from collections.abc import Iterable
 from distutils.version import StrictVersion
@@ -113,7 +112,6 @@ def fetch_json(remote_url,
         except Exception as e:
             raise e
     except Exception as e:
-        traceback.print_exc()
         raise RuntimeError(
             'Error while loading JSON data from {0}'.format(remote_url)) from e
     return data

--- a/powerdnsadmin/lib/utils.py
+++ b/powerdnsadmin/lib/utils.py
@@ -4,6 +4,7 @@ import json
 import requests
 import hashlib
 import ipaddress
+import traceback
 
 from collections.abc import Iterable
 from distutils.version import StrictVersion
@@ -105,6 +106,7 @@ def fetch_json(remote_url,
     try:
         data = json.loads(r.content.decode('utf-8'))
     except Exception as e:
+        traceback.print_exc()
         raise RuntimeError(
             'Error while loading JSON data from {0}'.format(remote_url)) from e
     return data

--- a/powerdnsadmin/lib/utils.py
+++ b/powerdnsadmin/lib/utils.py
@@ -105,6 +105,13 @@ def fetch_json(remote_url,
     data = None
     try:
         data = json.loads(r.content.decode('utf-8'))
+    except UnicodeDecodeError:
+        # If the decoding fails, switch to slower but probably working .json()
+        try:
+            logging.warning("UTF-8 content.decode failed, switching to slower .json method")
+            data = r.json()
+        except Exception as e:
+            raise e
     except Exception as e:
         traceback.print_exc()
         raise RuntimeError(


### PR DESCRIPTION
The data from Powerdns is parsed to json with json.loads(r.content.decode('utf-8'))
If this fails, PowerDNS-Admin stops working.

This pull request fixes this, by switching to  .json method on failure